### PR TITLE
Issue #43: Fix node v16 requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "build": "next build && prisma generate",
     "start": "next start"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/UseKeyp/od-bots.git"


### PR DESCRIPTION
Closes #43 

## Description
- Bumps node to 20 
- Tested locally to see if it works in the od-bots-dev channel and it does

<img width="693" alt="Screenshot 2024-02-20 at 12 14 51 PM" src="https://github.com/open-dollar/od-bot/assets/47253537/b8d14416-2b0c-45c3-9e4b-70ac756382d7">

However, the build fails because the app can't reach the supabase DB, which has been happening for the last 4 days it seems (even before I've upgraded) see build here for example: https://vercel.com/opendollar/od-bots-dev/8jHzuopoNgLg7ZzQKdm2C591MZD5

Can you check in supabase that the DB hasn't been paused? 
