### PR TITLE
Issue #63: Filter data by network

### DIFF
--- a/components/Charts.js
+++ b/components/Charts.js
@@ -1,10 +1,11 @@
 import { useQuery, gql } from "@apollo/client";
 import { Line } from "react-chartjs-2";
+// This linter marks this import as unused but it is needed
 import Chart from "chart.js/auto";
 
 const GET_STATS = gql`
-  query {
-    globalStats {
+  query GetGlobalStats($network: String) {
+    globalStats(network: $network) {
       createdAt
       updatedAt
       network
@@ -68,10 +69,14 @@ const getChartData = (data, labelName, key) => {
   };
 };
 
-const Charts = () => {
-  const { loading, error, data } = useQuery(GET_STATS);
+const Charts = ({ network }) => {
+  const { loading, error, data } = useQuery(GET_STATS, {
+    variables: { network },
+    skip: !network,
+  });
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error : {error.message}</p>;
+  if (!data?.globalStats) return <p>No data</p>;
 
   const erc20SupplyData = getChartData(
     data.globalStats,

--- a/components/Transactions.js
+++ b/components/Transactions.js
@@ -17,14 +17,14 @@ export function getExplorerBaseUrlFromName(name) {
       return `https://optimistic.etherscan.io/`;
     case "OPTIMISM_GOERLI":
       return `https://goerli-optimism.etherscan.io/`;
-    case "ARBITRUM_GOERLI":
-      return `https://goerli.arbiscan.io/`;
+    case "ARBITRUM_SEPOLIA":
+      return `https://sepolia.arbiscan.io/`;
   }
 }
 
 const GET_TXS = gql`
-  query {
-    recentTransactions {
+  query GetRecentTransactions($network: String) {
+    recentTransactions(network: $network) {
       createdAt
       updatedAt
       network
@@ -36,15 +36,22 @@ const GET_TXS = gql`
   }
 `;
 
-const Transactions = () => {
-  const { loading, error, data } = useQuery(GET_TXS);
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error : {error.message}</p>;
+const Transactions = ({ network }) => {
+  const { loading, error, data } = useQuery(GET_TXS, {
+    variables: { network },
+    skip: !network,
+  });
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+  if (error) {
+    return <p>Error : {error.message}</p>;
+  }
 
   if (data) {
     const transformedData = data.recentTransactions.map((tx) => [
       tx.method,
-      <a
+      <a key={tx.hash}
         className="underline font-blue "
         href={`${getExplorerBaseUrlFromName(tx.network)}tx/${tx.hash}`}
       >

--- a/components/Transactions.js
+++ b/components/Transactions.js
@@ -73,10 +73,10 @@ const Transactions = ({ network }) => {
             <TableColumn>DATE</TableColumn>
           </TableHeader>
           <TableBody>
-            {transformedData.map((tx, index) => (
-              <TableRow key={index}>
-                {tx.map((item) => (
-                  <TableCell key={index}>{item}</TableCell>
+            {transformedData.map((tx, rowIndex) => (
+              <TableRow key={rowIndex}>
+                {tx.map((item, cellIndex) => (
+                    <TableCell key={`row-${rowIndex}-cell-${cellIndex}`}>{item}</TableCell>
                 ))}
               </TableRow>
             ))}

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -2,11 +2,32 @@ import Head from "next/head";
 
 import Charts from "../components/Charts";
 import Transactions from "../components/Transactions";
-import Panel from "../components/Panel";
-import { Divider, Button, Spacer } from "@nextui-org/react";
+import {
+    Divider,
+    Button,
+    Spacer,
+    Dropdown,
+    DropdownTrigger,
+    DropdownMenu,
+    DropdownItem
+} from "@nextui-org/react";
+import { useState } from "react";
 
 export default function Home() {
-  return (
+    const [selectedNetwork, setSelectedNetwork] = useState('');
+
+    interface NetworkItem {
+        key: string;
+        label: string;
+    }
+
+    const networkItems: NetworkItem[] = [
+        { key: "ARBITRUM", label: "Arbitrum" },
+        { key: "OPTIMISM", label: "Optimism" },
+        { key: "ARBITRUM_SEPOLIA", label: "Arbitrum Sepolia" },
+    ];
+
+    return (
     <div className="items-center space-x-4 text-small">
       <Head>
         <title>🦗 Rate Update</title>
@@ -14,18 +35,22 @@ export default function Home() {
       </Head>
       <Spacer y={4} />
       <h1 className="">Open Dollar Bot</h1>
-      <Spacer y={4} />
-      <Divider className="my-4" />
-      <p>
-        Trigger the bot:
-        <br />
-        <code>{`/api/rate?key=<some-secret>`}</code>
-        <br />
-        <code>{`/api/oracle?key=<some-secret>`}</code>
-        <br />
-        <code>{`/api/analytics?key=<some-secret>`}</code>
-        <br />
-      </p>
+        <Spacer y={2} />
+        <Dropdown>
+            <DropdownTrigger>
+                <Button>Select Network</Button>
+            </DropdownTrigger>
+            <DropdownMenu
+                aria-label="Network Selection"
+                items={networkItems}
+                onAction={(key: any) => setSelectedNetwork(key)}
+            >
+                {(item: NetworkItem) => (
+                    <DropdownItem key={item.key}>{item.label}</DropdownItem>
+                )}
+            </DropdownMenu>
+        </Dropdown>
+        <Spacer y={4} />
       <Divider className="my-4" />
       <div className="">
         <a href="https://docs.opendollar.com" className="">
@@ -35,7 +60,7 @@ export default function Home() {
         </a>
       </div>
       <Divider className=" my-4" />
-      <Transactions />
+      <Transactions network={selectedNetwork} />
       <Divider className=" my-4" />
 
       {/* <div className="flex mt-20">

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -14,7 +14,7 @@ import {
 import { useState } from "react";
 
 export default function Home() {
-    const [selectedNetwork, setSelectedNetwork] = useState('');
+    const [selectedNetwork, setSelectedNetwork] = useState('ARBITRUM_SEPOLIA');
 
     interface NetworkItem {
         key: string;
@@ -27,6 +27,11 @@ export default function Home() {
         { key: "ARBITRUM_SEPOLIA", label: "Arbitrum Sepolia" },
     ];
 
+    const getSelectedNetworkLabel = () => {
+        const selectedItem = networkItems.find(item => item.key === selectedNetwork);
+        return selectedItem ? selectedItem.label : "Select Network";
+    };
+
     return (
     <div className="items-center space-x-4 text-small">
       <Head>
@@ -38,16 +43,18 @@ export default function Home() {
         <Spacer y={2} />
         <Dropdown>
             <DropdownTrigger>
-                <Button>Select Network</Button>
+                <Button>{getSelectedNetworkLabel()}</Button>
             </DropdownTrigger>
             <DropdownMenu
                 aria-label="Network Selection"
-                items={networkItems}
+                disallowEmptySelection
+                selectionMode="single"
+                selectedKeys={[selectedNetwork]}
                 onAction={(key: any) => setSelectedNetwork(key)}
             >
-                {(item: NetworkItem) => (
+                {networkItems.map((item: NetworkItem) => (
                     <DropdownItem key={item.key}>{item.label}</DropdownItem>
-                )}
+                ))}
             </DropdownMenu>
         </Dropdown>
         <Spacer y={4} />
@@ -75,7 +82,7 @@ export default function Home() {
         </div>
       </div> */}
 
-      <Charts />
+      <Charts network={selectedNetwork} />
       <Divider className="my-4" />
       <Divider className="my-4" />
 

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -6,7 +6,7 @@ import prisma from "../../lib/prisma";
 const typeDefs = gql`
   type Query {
     globalStats: [globalStats!]!
-    recentTransactions: [tx!]!
+    recentTransactions(network: String): [tx!]!
   }
 
   type tx {
@@ -46,17 +46,23 @@ const resolvers = {
     globalStats: () => {
       return prisma.globalStats.findMany();
     },
-    recentTransactions: () => {
+    recentTransactions: (_, args) => {
+      const whereClause = {
+        hash: {
+          not: null,
+        },
+      };
+
+      if (args.network) {
+        whereClause.network = args.network;
+      }
+
       return prisma.tx.findMany({
         take: 20,
         orderBy: {
           createdAt: "desc",
         },
-        where: {
-          hash: {
-            not: null,
-          },
-        },
+        where: whereClause,
       });
     },
   },

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -5,7 +5,7 @@ import prisma from "../../lib/prisma";
 
 const typeDefs = gql`
   type Query {
-    globalStats: [globalStats!]!
+    globalStats(network: String): [globalStats!]!
     recentTransactions(network: String): [tx!]!
   }
 
@@ -43,8 +43,16 @@ const typeDefs = gql`
 
 const resolvers = {
   Query: {
-    globalStats: () => {
-      return prisma.globalStats.findMany();
+    globalStats: (_, args) => {
+      const whereClause = {};
+
+      if (args.network) {
+        whereClause.network = args.network;
+      }
+
+      return prisma.globalStats.findMany({
+        where: whereClause,
+      });
     },
     recentTransactions: (_, args) => {
       const whereClause = {


### PR DESCRIPTION
Closes #63

## Description 
- [X] /pages/api/graphql query should allow filtering by network
- [X] ARBITRUM, ARBITRUM_SEPOLIA, OPTIMISM

Also added a dropdown on the UI to select one of these, but I'll make it nicer in the cleanup issue

- [X] Queries for chart data should also be filtered by network
- Deleted trigger the bot section since it's part of https://github.com/open-dollar/od-bot/issues/62
- [] Reset supabase database (can delete all data in od-bots project)

We're using Vercel not supabase now. Is it ok if I manually delete the content of the tables in the project?
I'll do 
```sql
DELETE * FROM tx;
DELETE * FROM globalStats;
DELETE * FROM tokenStats;
```

## Screenshots

Query works

https://github.com/open-dollar/od-bot/assets/47253537/27aa787a-100a-4c13-a9ec-d309642adb9f


