### PR TITLE
Issue #68: Add gas balance to error messages

### DIFF
--- a/lib/web3/oracle.js
+++ b/lib/web3/oracle.js
@@ -1,7 +1,8 @@
-import { botSendTx } from "./wallets/bot";
+import { botBalance, botSendTx } from "./wallets/bot";
 import { sendAlert } from "../discord/alert";
 import { getExplorerBaseUrlFromName, prepareTx } from "./common";
 import { Contract } from "@ethersproject/contracts";
+import { formatEther } from "@ethersproject/units";
 import { Web3Providers } from "./provider";
 
 import { initGeb } from "./geb";
@@ -110,23 +111,22 @@ export const updateResult = async (network, cType) => {
     return txResponse.hash;
   } catch (e) {
     console.log(e);
+    const gasBalance = await botBalance({ network });
+    const formattedGasBalance = formatEther(gasBalance);
     await sendAlert({
       embed: {
         color: 15548997,
         title: `🦉 DelayedOracle 🚫 FAILED | ${network}`,
         description: `updateResult() failed for ${collateral?.symbol}
-${txResponse?.hash
-            ? `[receipt](${getExplorerBaseUrlFromName(network)}tx/${txResponse.hash})
+        ${txResponse?.hash ? `[receipt](${getExplorerBaseUrlFromName(network)}tx/${txResponse?.hash})` : ""
+        }
+        Gas Balance: ${formattedGasBalance} ETH
 \`\`\`js
-${e}
-\`\`\``
-            : ""
-          }`,
+${e}\`\`\``,
         footer: { text: new Date().toString() },
       },
       channelName: "warning",
     });
-    return null;
   }
 };
 
@@ -156,23 +156,21 @@ export const updateCollateralPrice = async (network, cType) => {
     return txResponse.hash;
   } catch (e) {
     console.log(e);
+    const gasBalance = await botBalance({ network });
+    const formattedGasBalance = formatEther(gasBalance);
     await sendAlert({
       embed: {
         color: 15548997,
         title: `🦉 OracleRelayer 🚫 FAILED | ${network}`,
-        description: `updateCollateralPrice() failed for collateral ${collateral?.symbol
-          }
-${txResponse?.hash
-            ? `[receipt](${getExplorerBaseUrlFromName(network)}tx/${txResponse.hash})
+        description: `updateCollateralPrice() failed for collateral ${collateral?.symbol}
+${txResponse?.hash ? `[receipt](${getExplorerBaseUrlFromName(network)}tx/${txResponse?.hash})` : ""}
+Gas Balance: ${formattedGasBalance} ETH
 \`\`\`js
 ${e}
-\`\`\``
-            : ""
-          }`,
+\`\`\``,
         footer: { text: new Date().toString() },
       },
       channelName: "warning",
     });
-    return null;
   }
 };

--- a/lib/web3/oracle.js
+++ b/lib/web3/oracle.js
@@ -127,6 +127,7 @@ ${e}\`\`\``,
       },
       channelName: "warning",
     });
+    return null;
   }
 };
 
@@ -172,5 +173,6 @@ ${e}
       },
       channelName: "warning",
     });
+    return null;
   }
 };


### PR DESCRIPTION
Closes #68 

## Description
- Adds gas balance in error output for updateCollateralPrice() and updateResult()

## Screenshots

Output when testing locally and throwing an error

<img width="654" alt="error message" src="https://github.com/open-dollar/od-bot/assets/47253537/e22756be-f8a7-4aa3-b18d-bdc5900d9eb6">
