### PR TITLE
Issue #311: OD-1 CSP Configuration (od-bot PR)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,3 +1,5 @@
+import { NextResponse } from "next/server";
+
 export function middleware(request) {
   const authHeader = request.headers.get("authorization");
 
@@ -10,6 +12,44 @@ export function middleware(request) {
       status: 401,
     });
   }
+
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+  const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic';
+    style-src 'self' 'nonce-${nonce}';
+    img-src 'self' blob: data:;
+    font-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+`
+  // Replace newline characters and spaces
+  const contentSecurityPolicyHeaderValue = cspHeader
+      .replace(/\s{2,}/g, ' ')
+      .trim()
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-nonce', nonce)
+
+  requestHeaders.set(
+      'Content-Security-Policy',
+      contentSecurityPolicyHeaderValue
+  )
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
+  response.headers.set(
+      'Content-Security-Policy',
+      contentSecurityPolicyHeaderValue
+  )
+
+  return response
 }
 
 export const config = {


### PR DESCRIPTION
Relates to https://github.com/open-dollar/od-app/issues/311

## Description
- Added a CSP for Next.js in the middleware file as recommended by their official docs: https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy

## Screenshots

Discord bots still working

<img width="551" alt="claim works" src="https://github.com/open-dollar/od-bot/assets/47253537/0285bb18-8dda-448b-acfb-1c283d2b87c5">

Discord bots still working pt. 2

<img width="702" alt="oracle working" src="https://github.com/open-dollar/od-bot/assets/47253537/5304d6ce-0d10-43fc-ae94-411e18903232">

No CSP console errors when reloading

https://github.com/open-dollar/od-bot/assets/47253537/f7564df8-f1b0-4fbe-8690-ba671793aa33


No CSP console errors when switching networks

https://github.com/open-dollar/od-bot/assets/47253537/b529d961-ca18-4bb7-b771-9b1a921e0b2d




