### PR TITLE
Issue #76: OD-5 Ensure claim is disabled on mainnet

### DIFF
--- a/lib/web3/common.js
+++ b/lib/web3/common.js
@@ -24,6 +24,10 @@ export const AVAILABLE_NETWORKS = [
   "ARBITRUM_SEPOLIA",
 ];
 
+export const AVAILABLE_MAINNET_NETWORKS = new Set(
+    ["OPTIMISM", "ARBITRUM"]
+)
+
 export function getAlchemyNetworkEnum(network) {
   switch (network) {
     case "MAINNET":

--- a/pages/api/claim.js
+++ b/pages/api/claim.js
@@ -1,4 +1,5 @@
 import { claim } from "../../lib/web3/claim";
+import { AVAILABLE_MAINNET_NETWORKS } from "../../lib/web3/common";
 
 const ARBITRUM_SEPOLIA = "ARBITRUM_SEPOLIA";
 
@@ -6,6 +7,10 @@ export default async function handler(request, response) {
   try {
     let network = ARBITRUM_SEPOLIA;
     if (request.query.network) network = request.query.network;
+
+    if (AVAILABLE_MAINNET_NETWORKS.has(network)) {
+      return response.status(403).json({ success: false, error: '/claim is not allowed for mainnet networks like ' + network})
+    }
 
     await claim(network, request.query.address, request.query.channel);
 


### PR DESCRIPTION
Closes #76 

## Description
- Ensures that the /claim endpoint is disabled for mainnet networks that we support (Arbitrum, Optimism)

## Screenshots

Claim works on testnets 

<img width="779" alt="claim works testnet" src="https://github.com/open-dollar/od-bot/assets/47253537/19978a7b-834d-4ee6-bf88-888e94c453b5">

Claim not allowed on mainnets

<img width="808" alt="disable claim" src="https://github.com/open-dollar/od-bot/assets/47253537/6c35ec66-9564-4012-b70c-a74d2db05023">
