### PR TITLE
Fix circulating and totalsupply to return raw JSON response

### DIFF
--- a/pages/api/circulating.js
+++ b/pages/api/circulating.js
@@ -56,7 +56,7 @@ export default async function handler(request, response) {
 
         const formattedCirculatingSupply = formatUnits(circulatingSupply.toString(), 18);
 
-        response.status(200).json({ success: true, circulating: formattedCirculatingSupply });
+        response.status(200).json(formattedCirculatingSupply);
     } catch (e) {
         console.error(e);
         return response.status(500).json({ success: false, error: e.message });

--- a/pages/api/circulating.js
+++ b/pages/api/circulating.js
@@ -56,7 +56,7 @@ export default async function handler(request, response) {
 
         const formattedCirculatingSupply = formatUnits(circulatingSupply.toString(), 18);
 
-        response.status(200).json(formattedCirculatingSupply);
+        response.status(200).json(Number(formattedCirculatingSupply));
     } catch (e) {
         console.error(e);
         return response.status(500).json({ success: false, error: e.message });

--- a/pages/api/totalsupply.js
+++ b/pages/api/totalsupply.js
@@ -39,7 +39,7 @@ export default async function handler(request, response) {
 
         const formattedSupply = formatUnits(totalSupply.toString(), 18);
 
-        response.status(200).json({ success: true, totalSupply: formattedSupply });
+        response.status(200).json(formattedSupply);
     } catch (e) {
         console.error(e);
         return response.status(500).json({ success: false, error: e.message });

--- a/pages/api/totalsupply.js
+++ b/pages/api/totalsupply.js
@@ -39,7 +39,7 @@ export default async function handler(request, response) {
 
         const formattedSupply = formatUnits(totalSupply.toString(), 18);
 
-        response.status(200).json(formattedSupply);
+        response.status(200).json(Number(formattedSupply));
     } catch (e) {
         console.error(e);
         return response.status(500).json({ success: false, error: e.message });


### PR DESCRIPTION
## Description
- Changed circulating and total supply to just return the raw JSON responses as a number


<img width="601" alt="Screenshot 2024-05-31 at 8 04 14 PM" src="https://github.com/open-dollar/od-bot/assets/47253537/e87740a5-9e8b-49b4-9720-1e8c5c656829">

<img width="644" alt="Screenshot 2024-05-31 at 8 04 21 PM" src="https://github.com/open-dollar/od-bot/assets/47253537/32c62e37-6330-4bf6-8e98-5772947af78b">
