### PR TITLE
Issue #106: Bolts: fetch user total deposit USD

### DIFF
--- a/lib/userDeposits.js
+++ b/lib/userDeposits.js
@@ -1,0 +1,40 @@
+import { getUserVaults } from "./userVaults"
+import { initGeb } from "./web3/geb"
+import { fetchAnalyticsData } from "@opendollar/sdk/lib/virtual/virtualAnalyticsData"
+import { formatUnits } from "@ethersproject/units"
+
+export const getUserDeposits = async (address, network) => {
+    let geb
+    try {
+        geb = initGeb(network)
+        if (!geb) {
+            throw new Error('Failed to initialize GEB')
+        }
+    } catch (e) {
+        throw new Error('Failed to initialize GEB')
+    }
+
+    const userVaults = await getUserVaults(address, network)
+    const vaults = userVaults.vaults
+
+    const analyticsData = await fetchAnalyticsData(geb)
+
+    const collateralPrices = Object.entries(analyticsData.tokenAnalyticsData).reduce((acc, [key, value]) => {
+        acc[key] = parseFloat(formatUnits(value.currentPrice, 18))
+        return acc
+    }, {})
+
+    let totalCollateralInUSD = 0
+
+    vaults.forEach(vault => {
+        const collateralType = vault.collateralType
+        const collateralAmount = parseFloat(formatUnits(vault.collateral, 18))
+        const collateralPrice = collateralPrices[collateralType]
+
+        if (collateralAmount && collateralPrice) {
+            totalCollateralInUSD += collateralAmount * collateralPrice
+        }
+    })
+
+    return { totalCollateralInUSD: totalCollateralInUSD.toFixed(2) }
+}

--- a/lib/vaults.js
+++ b/lib/vaults.js
@@ -1,0 +1,40 @@
+import { initGeb } from "./web3/geb"
+import { postQuery } from "./utils"
+
+export const getVaults = async (network) => {
+    let geb
+    try {
+        geb = initGeb(network)
+        if (!geb) {
+            throw new Error('Failed to initialize GEB')
+        }
+    } catch (e) {
+        throw new Error('Failed to initialize GEB')
+    }
+
+    const query = `query AllUsers {
+        vaults(first:1000) {
+            id
+            owner
+            collateral
+            debt
+            collateralType
+        }
+    }`
+
+    const variables = {
+        "first": 1000
+    }
+
+    const headers = {
+        'Content-Type': 'application/json'
+    }
+
+    const data = await postQuery(geb.subgraph, query, variables, headers)
+
+    if (data.errors) {
+        throw new Error(data.errors.map(error => error.message).join(", "))
+    }
+
+    return data.data.vaults
+}

--- a/pages/api/userdeposits.js
+++ b/pages/api/userdeposits.js
@@ -1,0 +1,23 @@
+import { getUserDeposits } from "../../lib/userDeposits"
+
+const ARBITRUM = "ARBITRUM"
+
+export default async function handler(request, response) {
+    try {
+        let network = ARBITRUM
+        if (request.query.network) network = request.query.network
+
+        const { address } = request.query
+
+        if (!address) {
+            return response.status(400).json({ success: false, error: "Address parameter is required" })
+        }
+
+        const result = await getUserDeposits(address, network)
+
+        response.status(200).json({ success: true, totalCollateralInUSD: result.totalCollateralInUSD })
+    } catch (e) {
+        console.error(e)
+        response.status(500).json({ success: false, error: e.message })
+    }
+}


### PR DESCRIPTION
closes #106 

## Description
- [X] Move the code in `/pages/api/vaults` to a separate re-usable function. For all future endpoints, the internal logic should always be in `/lib`, for example: `getUserVaults` for the `/uservaults` endpoint
- [X] Create a new endpoint `/userdeposits` 
- [X] Get all vaults

This requirement says "get all vaults" but I assume you meant "get all vaults the user owns". Let me know if that's incorrect. I called the getUserVaults function

- [X] Get the current price for each collateral type using the oracles in the sdk 
- [X] For each user, calculate the total amount of collateral in their vaults, and convert to USD. No need to include the debt for these calculations
- [ ] Communicate to Turtle club once complete

I haven't sent this to the Turtle club yet--let me know if you think the implementation is good

Note that I've noticed sometimes the result from the API response is different from what is shown on the UI by a couple cents, should I investigate more? Maybe a rounding error or maybe this isn't the best way to fetch oracle prices...

Example 1, collateral > 0, user has 1 vault

<img width="942" alt="examples collateral amount success" src="https://github.com/open-dollar/od-bot/assets/47253537/c923764a-2b72-4e38-9402-7c02abf7e1a7">

Example 2, collateral === 0

<img width="1128" alt="0 case" src="https://github.com/open-dollar/od-bot/assets/47253537/ecdef4b1-ba96-4e35-a5ac-fe8d3244aab5">

In the below examples the user has 2 vaults 
$38,453.40 + $3,023.47 = $41,476.87

Example 3a, user has 2 vaults, this is the first vault

<img width="1297" alt="ot 1" src="https://github.com/open-dollar/od-bot/assets/47253537/6d0f103a-7159-4bf2-baea-4a8a87b170e3">

Example 3b, user has 2 vaults, this is the second vault

<img width="1252" alt="pt  2" src="https://github.com/open-dollar/od-bot/assets/47253537/71d3387a-bad1-4ad4-936a-58fd856248bc">
